### PR TITLE
Fixed hrd 1 crash issues caused by writeUvlc long bits, memmove and

### DIFF
--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -4749,10 +4749,22 @@ static void WriteUvlc(
 		numberOfBits += 2;
 	}
 
-	OutputBitstreamWrite(
-		bitstreamPtr,
-		bits,
-		numberOfBits);
+    if(numberOfBits<32) {
+	    OutputBitstreamWrite(
+		    bitstreamPtr,
+		    bits,
+		    numberOfBits);
+    } else
+    {
+	    OutputBitstreamWrite(
+		    bitstreamPtr,
+		    0,
+		    numberOfBits>>1);
+	    OutputBitstreamWrite(
+		    bitstreamPtr,
+		    bits,
+		    (numberOfBits+1)>>1);
+    }
 }
 
 /**************************************************
@@ -8330,17 +8342,6 @@ EB_ERRORTYPE CodeBufferingPeriodSEI(
 			bufferingPeriodPtr->rapCpbParamsPresentFlag);
 	}
 
-	// concatenation_flag
-	WriteFlagCavlc(
-		bitstreamPtr,
-		bufferingPeriodPtr->concatenationFlag);
-
-	// au_cpb_removal_delay_delta_minus1
-	WriteCodeCavlc(
-		bitstreamPtr,
-		bufferingPeriodPtr->auCpbRemovalDelayDeltaMinus1,
-		vuiPtr->hrdParametersPtr->auCpbRemovalDelayLengthMinus1 + 1);
-
 	if (bufferingPeriodPtr->rapCpbParamsPresentFlag){
 		// cpb_delay_offset
 		WriteCodeCavlc(
@@ -8353,6 +8354,17 @@ EB_ERRORTYPE CodeBufferingPeriodSEI(
 			bufferingPeriodPtr->dpbDelayOffset,
 			vuiPtr->hrdParametersPtr->dpbOutputDelayDuLengthMinus1 + 1);
 	}
+
+	// concatenation_flag
+	WriteFlagCavlc(
+		bitstreamPtr,
+		bufferingPeriodPtr->concatenationFlag);
+
+	// au_cpb_removal_delay_delta_minus1
+	WriteCodeCavlc(
+		bitstreamPtr,
+		bufferingPeriodPtr->auCpbRemovalDelayDeltaMinus1,
+		vuiPtr->hrdParametersPtr->auCpbRemovalDelayLengthMinus1 + 1);
 
 	for (nalVclIndex = 0; nalVclIndex < 2; ++nalVclIndex){
 		if ((nalVclIndex == 0 && vuiPtr->hrdParametersPtr->nalHrdParametersPresentFlag) ||

--- a/Source/Lib/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Codec/EbPacketizationProcess.c
@@ -808,7 +808,7 @@ void* PacketizationKernel(void *inputPtr)
                 startinBytes = queueEntryPtr->startSplicing;
                 totalBytes = outputStreamPtr->nFilledLen;
                 //Shift the bitstream by size of picture timing SEI
-                memcpy(outputStreamPtr->pBuffer + startinBytes + bufferWrittenBytesCount, outputStreamPtr->pBuffer + startinBytes, totalBytes - startinBytes);
+                memmove(outputStreamPtr->pBuffer + startinBytes + bufferWrittenBytesCount, outputStreamPtr->pBuffer + startinBytes, totalBytes - startinBytes);
                 // Copy Picture Timing SEI to the Output Bitstream
                 CopyRbspBitstreamToPayload(
                     queueEntryPtr->bitStreamPtr2,

--- a/Source/Lib/Codec/EbSei.c
+++ b/Source/Lib/Codec/EbSei.c
@@ -452,12 +452,6 @@ EB_U32 GetBufPeriodSEILength(
         seiLength += 1;
     }
 
-    // concatenation_flag
-    seiLength += 1;
-
-    // au_cpb_removal_delay_delta_minus1
-    seiLength += vuiPtr->hrdParametersPtr->auCpbRemovalDelayLengthMinus1 + 1;
-
     if(bufferingPeriodPtr->rapCpbParamsPresentFlag) {
         // cpb_delay_offset
         seiLength += vuiPtr->hrdParametersPtr->initialCpbRemovalDelayLengthMinus1 + 1;
@@ -465,6 +459,12 @@ EB_U32 GetBufPeriodSEILength(
         // dpb_delay_offset
         seiLength += vuiPtr->hrdParametersPtr->dpbOutputDelayDuLengthMinus1 + 1;
     }
+
+    // concatenation_flag
+    seiLength += 1;
+
+    // au_cpb_removal_delay_delta_minus1
+    seiLength += vuiPtr->hrdParametersPtr->auCpbRemovalDelayLengthMinus1 + 1;
 
     for(nalVclIndex = 0; nalVclIndex < 2; ++nalVclIndex) {
         if((nalVclIndex == 0 && vuiPtr->hrdParametersPtr->nalHrdParametersPresentFlag) ||
@@ -499,7 +499,7 @@ EB_U32 GetActiveParameterSetSEILength(
     EB_U32       seiLength = 0;
 
     // active_video_parameter_set_id
-    seiLength += GetUvlcCodeLength(activeParameterSet->activeVideoParameterSetid);
+    seiLength += 4;
 
     // self_contained_cvs_flag
     seiLength += 1;


### PR DESCRIPTION
SEIPeriod issues

Signed-off-by: Hu, Kelvin <kelvin.hu@intel.com>